### PR TITLE
actualize valid range for magic headers

### DIFF
--- a/docs/tunnels.md
+++ b/docs/tunnels.md
@@ -129,22 +129,22 @@ When using AmneziaWG, you can configure these optional parameters for enhanced D
     - Purpose: Randomizes length (len(resp) = 92 + S2) for pattern disruption.
 
 - **H1 (Init Packet Magic Header)**: Random constant replacing predictable WireGuard identifier for initial packets.
-    - Valid Range: 0–2147483647 (unique from H2/H3/H4)
+    - Valid Range: 0–4294967295 (unique from H2/H3/H4)
     - Recommended: 1
     - Purpose: Resists DPI filtering by making headers unique per client.
 
 - **H2 (Response Packet Magic Header)**: Random constant for response packets.
-    - Valid Range: 0–2147483647 (unique)
+    - Valid Range: 0–4294967295 (unique)
     - Recommended: 2
     - Purpose: Obfuscates handshake replies.
 
 - **H3 (Underload Packet Magic Header)**: Random constant for keep-alive packets.
-    - Valid Range: 0–2147483647 (unique)
+    - Valid Range: 0–4294967295 (unique)
     - Recommended: 3
     - Purpose: Masks minimal data transfer to prevent DPI filtering of short pings.
 
 - **H4 (Transport Packet Magic Header)**: Random constant for data transport packets.
-    - Valid Range: 0–2147483647 (unique)
+    - Valid Range: 0–4294967295 (unique)
     - Recommended: 4
     - Purpose: Conceals regular traffic patterns.
 


### PR DESCRIPTION
`uint32` valid range `0-4294967295`

## example

`H1 = 2147483648-2684354559`
`H2 = 2684354560-3221225471`
`H3 = 3221225472-3758096383`
`H4 = 3758096384-4294967295`

## reference

https://docs.amnezia.org/documentation/amnezia-wg/

https://github.com/amnezia-vpn/amneziawg-go/commit/12a012205e3c444be02aba91a840455f74c127e1
